### PR TITLE
add fix for focused textfield to look 'active' even if the value is empt...

### DIFF
--- a/lib/assets/javascripts/cmi/form_components/text_field.coffee
+++ b/lib/assets/javascripts/cmi/form_components/text_field.coffee
@@ -4,7 +4,7 @@ window.CMI.FormComponents or= {}
 class CMI.FormComponents.TextField
 
   @reset: (domElement) ->
-    if domElement.val().length > 0
+    if domElement.val().length > 0 || domElement.is(':focus')
       domElement.parents(@_getInputBoxSelector()).addClass('cmi-active')
     else
       domElement.parents(@_getInputBoxSelector()).removeClass('cmi-active')


### PR DESCRIPTION
i add a fix for focused textfields which does not look 'active' after page reload when the value was empty, now the look 'active'
